### PR TITLE
Remove leading zeros from days, and hours

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -9,7 +9,7 @@ build:
           diff -q example.test example
     - script:
         name: auto-version
-        code: export VERSION=$(date +%Y.%j.%H%M)
+        code: export VERSION=$(date +%Y.%-j.%-H%M)
     # We have to go deeper
     - termie/bash-template
     - script:


### PR DESCRIPTION
Leading zeros are invalid for semver.

Also, please do not use this versioning scheme for future wercker steps:

Having the major version increment indicates a backwards incompatible change. Currently there is no way of doing this. Plus it happens every year, for no reason.